### PR TITLE
Create portainer-deploy.yml

### DIFF
--- a/.github/workflows/portainer-deploy.yml
+++ b/.github/workflows/portainer-deploy.yml
@@ -1,0 +1,61 @@
+name: Redeploy Portaianer via Portainer GitOps
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'portainer-compose.yml'
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install WireGuard
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wireguard resolvconf
+      - name: Write WireGuard config
+        run: |
+          echo "${{ secrets.WG_CONFIG }}" > wg0.conf
+      - name: Resolve DDNS and update wg0.conf
+        run: |
+          sudo apt-get update && sudo apt-get install -y dnsutils
+          ip=$(dig +short 14monarch.tplinkdns.com @8.8.8.8 | tail -n1)
+          if [ -z "$ip" ]; then
+          echo "❌ Failed to resolve 14monarch.tplinkdns.com"
+          exit 1
+          fi
+          echo "✅ Resolved 14monarch.tplinkdns.com to $ip"
+          sudo sed -i "s|14monarch.tplinkdns.com|$ip|" wg0.conf
+          echo "🔧 Updated wg0.conf to use $ip instead of DDNS"
+      - name: Bring up VPN
+        run: |
+          sudo wg-quick up ./wg0.conf
+          sudo wg show
+      - name: Remove Swarm Stack
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: liam-pi4
+          username: ${{ secrets.PI_USER }}
+          password: ${{ secrets.PI_PASSWORD }}
+          script: |
+            docker stack rm portainer          
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: liam-pi4
+          username: ${{ secrets.PI_USER }}
+          password: ${{ secrets.PI_PASSWORD }}
+          script: |
+            cd ~/stacks/portainer
+            cat > docker-compose.yml <<'EOF'
+            $(cat portainer-compose.yml)
+            EOF
+            docker compose up -d
+#      - name: Call Portainer webhook
+#        run: |
+#          curl -X POST \
+#            http://portainer.14monarch.local/api/stacks/webhooks/xxxxxx


### PR DESCRIPTION
Deploys the stack using non-swarm docker compose. Should be able to implement via webhook once done