### PR TITLE
Add healthchecks

### DIFF
--- a/nextcloud-compose.yml
+++ b/nextcloud-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - nginx_network
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -pexample || exit 1"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/nginx-compose.yml
+++ b/nginx-compose.yml
@@ -16,7 +16,7 @@ services:
       PASSWORD_ADMIN: ${Admin_Password}
       USERNAME_ADMIN: ${Admin_User}
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost || exit 1"]
+      test: ["CMD", "/usr/bin/check-health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/portainer-compose.yml
+++ b/portainer-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       - nginx_network  
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9000 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:83 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Changing the healthchecks for mariadb, nginx and portainer
The portainer and mariadb were saying unhelathy and the nginx one not properly implemented as the status was just "running"
