### PR TITLE
Auto-discover certificate path by matching OCI cert domain

### DIFF
--- a/oci-cert-updater/Dockerfile
+++ b/oci-cert-updater/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 LABEL maintainer="LJF Cloud"
 LABEL description="Uploads renewed NPM certificates to OCI Certificates Service"
 
-RUN pip install --no-cache-dir oci
+RUN pip install --no-cache-dir oci cryptography
 
 WORKDIR /app
 

--- a/oci-cert-updater/oci-cert-updater-compose.yml
+++ b/oci-cert-updater/oci-cert-updater-compose.yml
@@ -6,7 +6,6 @@ services:
     container_name: oci-cert-updater
     restart: unless-stopped
     environment:
-      - CERT_PATH=${CERT_PATH:-/etc/letsencrypt/live/npm-2}
       - OCI_CERT_ID=${OCI_CERT_ID}
       - CHECK_INTERVAL=${CHECK_INTERVAL:-3600}
       - OCI_USER=${OCI_USER}

--- a/oci-cert-updater/update_certificate.py
+++ b/oci-cert-updater/update_certificate.py
@@ -7,26 +7,14 @@ import hashlib
 import base64
 import oci
 from datetime import datetime
-
-
-def _resolve_cert_path(configured_path: str) -> str:
-    """Return configured_path if it exists, otherwise auto-discover from /etc/letsencrypt/live/."""
-    if os.path.isdir(configured_path):
-        return configured_path
-    live_dir = '/etc/letsencrypt/live'
-    if os.path.isdir(live_dir):
-        for entry in sorted(os.listdir(live_dir)):
-            candidate = os.path.join(live_dir, entry)
-            if os.path.isfile(os.path.join(candidate, 'fullchain.pem')):
-                print(f"[INFO] Configured path '{configured_path}' not found; using auto-discovered '{candidate}'", flush=True)
-                return candidate
-    return configured_path  # Fall back so the original error surfaces clearly
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
 
 
 # Configuration
-CERT_PATH = _resolve_cert_path(os.getenv('CERT_PATH', '/etc/letsencrypt/live/npm-2'))
 OCI_CERT_ID = os.getenv('OCI_CERT_ID')
 CHECK_INTERVAL = int(os.getenv('CHECK_INTERVAL', '3600'))
+CERT_PATH_OVERRIDE = os.getenv('CERT_PATH')  # optional explicit override
 
 # OCI credentials
 oci_key_base64 = os.getenv('OCI_KEY_CONTENT_BASE64')
@@ -49,11 +37,68 @@ def log(message):
     print(f"[{timestamp}] {message}", flush=True)
 
 
-def read_cert_files():
+def get_pem_names(fullchain_path: str) -> set:
+    """Return all CN + SAN DNS names from the first cert in a PEM file."""
+    with open(fullchain_path, 'rb') as f:
+        pem_data = f.read()
+    cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+    names = set()
+    cn_attrs = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+    if cn_attrs:
+        names.add(cn_attrs[0].value)
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        names.update(name.value for name in san.value.get_values_for_type(x509.DNSName))
+    except x509.ExtensionNotFound:
+        pass
+    return names
+
+
+def find_cert_path(client) -> str:
+    """Find the letsencrypt cert dir whose CN/SAN matches the OCI certificate."""
+    if CERT_PATH_OVERRIDE:
+        log(f"Using explicit CERT_PATH: {CERT_PATH_OVERRIDE}")
+        return CERT_PATH_OVERRIDE
+
+    log("No CERT_PATH set — discovering cert path by matching domain against OCI cert...")
+
+    oci_cert = client.get_certificate(OCI_CERT_ID).data
+    domain = oci_cert.subject.common_name
+    if not domain:
+        log("ERROR: OCI cert has no common name — set CERT_PATH explicitly.")
+        sys.exit(1)
+    log(f"OCI cert domain: {domain}")
+
+    live_dir = '/etc/letsencrypt/live'
+    if not os.path.isdir(live_dir):
+        log(f"ERROR: {live_dir} does not exist — is the letsencrypt volume mounted?")
+        sys.exit(1)
+
+    for entry in sorted(os.listdir(live_dir)):
+        candidate = os.path.join(live_dir, entry)
+        fullchain = os.path.join(candidate, 'fullchain.pem')
+        if not os.path.isfile(fullchain):
+            continue
+        try:
+            names = get_pem_names(fullchain)
+            # Also check wildcard match (e.g. *.example.com covers sub.example.com)
+            parts = domain.split('.')
+            wildcard = f'*.{".".join(parts[1:])}' if len(parts) > 2 else None
+            if domain in names or (wildcard and wildcard in names):
+                log(f"Matched cert dir: {candidate} (names: {', '.join(sorted(names))})")
+                return candidate
+        except Exception as e:
+            log(f"WARN: Could not parse {fullchain}: {e}")
+
+    log(f"ERROR: No cert in {live_dir} matches domain '{domain}'. Set CERT_PATH explicitly.")
+    sys.exit(1)
+
+
+def read_cert_files(cert_path: str):
     """Read cert files and return (fullchain, chain, privkey) or raise."""
-    fullchain_path = os.path.join(CERT_PATH, 'fullchain.pem')
-    chain_path = os.path.join(CERT_PATH, 'chain.pem')
-    privkey_path = os.path.join(CERT_PATH, 'privkey.pem')
+    fullchain_path = os.path.join(cert_path, 'fullchain.pem')
+    chain_path = os.path.join(cert_path, 'chain.pem')
+    privkey_path = os.path.join(cert_path, 'privkey.pem')
 
     with open(fullchain_path, 'r') as f:
         fullchain = f.read()
@@ -65,18 +110,18 @@ def read_cert_files():
     return fullchain, chain, privkey
 
 
-def get_cert_hash():
+def get_cert_hash(cert_path: str) -> str:
     """Return SHA256 hash of fullchain.pem + privkey.pem content."""
-    fullchain, _, privkey = read_cert_files()
+    fullchain, _, privkey = read_cert_files(cert_path)
     h = hashlib.sha256()
     h.update(fullchain.encode())
     h.update(privkey.encode())
     return h.hexdigest()
 
 
-def upload_certificate(client):
+def upload_certificate(client, cert_path: str):
     """Upload current cert files as a new version in OCI."""
-    fullchain, chain, privkey = read_cert_files()
+    fullchain, chain, privkey = read_cert_files(cert_path)
 
     update_details = oci.certificates_management.models.UpdateCertificateDetails(
         certificate_config=oci.certificates_management.models.UpdateCertificateByImportingConfigDetails(
@@ -93,7 +138,6 @@ def upload_certificate(client):
 
 def main():
     log("=== OCI Certificate Updater Starting ===")
-    log(f"Cert path: {CERT_PATH}")
     log(f"OCI Cert ID: {OCI_CERT_ID}")
     log(f"Check interval: {CHECK_INTERVAL}s")
     log(f"Region: {config['region']}")
@@ -113,13 +157,16 @@ def main():
         log(f"ERROR: Failed to initialise OCI client: {e}")
         sys.exit(1)
 
+    cert_path = find_cert_path(client)
+    log(f"Cert path: {cert_path}")
+
     # Get baseline hash
     try:
-        current_hash = get_cert_hash()
+        current_hash = get_cert_hash(cert_path)
         log(f"Baseline cert hash: {current_hash[:12]}...")
         # Upload on first run to ensure OCI is in sync
         log("Uploading cert on startup to ensure OCI is in sync...")
-        upload_certificate(client)
+        upload_certificate(client, cert_path)
     except Exception as e:
         log(f"ERROR: Failed on startup: {e}")
         sys.exit(1)
@@ -127,10 +174,10 @@ def main():
     while True:
         try:
             time.sleep(CHECK_INTERVAL)
-            new_hash = get_cert_hash()
+            new_hash = get_cert_hash(cert_path)
             if new_hash != current_hash:
                 log(f"Cert change detected (hash: {new_hash[:12]}...). Uploading to OCI...")
-                upload_certificate(client)
+                upload_certificate(client, cert_path)
                 current_hash = new_hash
             else:
                 log("Cert unchanged, skipping upload.")


### PR DESCRIPTION
## Summary
This PR refactors the certificate path handling to support automatic discovery based on domain matching, eliminating the need for explicit `CERT_PATH` configuration in most cases.

## Key Changes
- **Automatic certificate discovery**: Added `find_cert_path()` function that queries the OCI certificate to extract its domain, then searches `/etc/letsencrypt/live` to find the matching certificate directory by comparing CN and SAN DNS names
- **Domain matching logic**: Implemented `get_pem_names()` to extract all CN and SAN DNS names from a certificate, with support for wildcard certificate matching (e.g., `*.example.com` matches `sub.example.com`)
- **Optional explicit override**: Kept `CERT_PATH_OVERRIDE` environment variable for cases where automatic discovery isn't suitable
- **Removed hardcoded default**: Eliminated the hardcoded `/etc/letsencrypt/live/npm-2` default path
- **Updated dependencies**: Added `cryptography` library to Dockerfile for certificate parsing
- **Refactored functions**: Modified `read_cert_files()`, `get_cert_hash()`, and `upload_certificate()` to accept `cert_path` as a parameter instead of using a global constant
- **Simplified compose file**: Removed `CERT_PATH` environment variable from docker-compose configuration

## Implementation Details
- Certificate discovery runs once at startup via `find_cert_path(client)` before entering the monitoring loop
- Graceful error handling with informative messages if OCI cert has no CN or no matching local certificate is found
- Wildcard matching handles both exact domain matches and wildcard certificate scenarios
- Maintains backward compatibility through the optional `CERT_PATH_OVERRIDE` environment variable

https://claude.ai/code/session_01T7XWd3ECBhRPZb6G71e8iF