### PR TITLE
Add WAF Network Address List update for 14monarch IP

### DIFF
--- a/.github/workflows/oci-containers-deploy.yml
+++ b/.github/workflows/oci-containers-deploy.yml
@@ -289,6 +289,10 @@ jobs:
                                     "name":"NSG_ID",
                                     "value":"${{ vars.OCID_HOME_TO_VM_NSG }}"
                                     },
+                                    {
+                                    "name":"WAF_ALLOWLIST_ID",
+                                    "value":"${{ vars.ocid_WAF_allowlist }}"
+                                    },
                                    {
                                     "name":"DUCKDNS_TOKEN",
                                     "value":"${{ secrets.DUCKDNS_TOKEN }}"
@@ -340,6 +344,10 @@ jobs:
                                       {
                                       "name":"NSG_ID",
                                       "value":"${{ vars.OCID_HOME_TO_VM_NSG }}"
+                                      },
+                                      {
+                                      "name":"WAF_ALLOWLIST_ID",
+                                      "value":"${{ vars.ocid_WAF_allowlist }}"
                                       },
                                       {
                                       "name":"DUCKDNS_TOKEN",

--- a/dynamic-ip-updater/dynamic-ip-updater-compose.yml
+++ b/dynamic-ip-updater/dynamic-ip-updater-compose.yml
@@ -13,6 +13,7 @@ services:
       # OCI Security List ID
       - SECURITY_LIST_ID=${SECURITY_LIST_ID}
       - NSG_ID=${OCID_HOME_TO_VM_NSG}
+      - WAF_ALLOWLIST_ID=${WAF_ALLOWLIST_ID}
       # OCI Credentials
       - OCI_USER=${OCI_USER}
       - OCI_FINGERPRINT=${OCI_FINGERPRINT}

--- a/dynamic-ip-updater/update_security_list.py
+++ b/dynamic-ip-updater/update_security_list.py
@@ -12,6 +12,7 @@ from datetime import datetime
 HOSTNAME = os.getenv('HOSTNAME', '14monarch.tplinkdns.com')
 SECURITY_LIST_ID = os.getenv('SECURITY_LIST_ID')
 NSG_ID = os.getenv('NSG_ID')
+WAF_ALLOWLIST_ID = os.getenv('WAF_ALLOWLIST_ID')
 CHECK_INTERVAL = int(os.getenv('CHECK_INTERVAL', '300'))  # Default: 5 minutes
 PORTS = [22]  # SSH
 
@@ -169,6 +170,42 @@ def update_nsg(virtual_network_client, new_ip):
         return False
 
 
+def update_waf_allowlist(waf_client, old_ip, new_ip):
+    """Update WAF Network Address List with new IP, replacing the old one"""
+    if not WAF_ALLOWLIST_ID:
+        return True  # Skip silently if not configured
+
+    try:
+        # Get current address list
+        response = waf_client.get_network_address_list(WAF_ALLOWLIST_ID)
+        current_addresses = list(response.data.addresses) if response.data.addresses else []
+
+        # Remove old IP entry if present
+        if old_ip:
+            old_cidr = f"{old_ip}/32"
+            current_addresses = [a for a in current_addresses if a != old_cidr]
+            log(f"Removed old WAF allowlist entry: {old_cidr}")
+
+        # Add new IP if not already present
+        new_cidr = f"{new_ip}/32"
+        if new_cidr not in current_addresses:
+            current_addresses.append(new_cidr)
+
+        waf_client.update_network_address_list(
+            WAF_ALLOWLIST_ID,
+            oci.waf.models.UpdateNetworkAddressListAddressesDetails(
+                addresses=current_addresses
+            )
+        )
+
+        log(f"✓ WAF allowlist updated successfully with IP: {new_ip}")
+        return True
+
+    except Exception as e:
+        log(f"ERROR: Failed to update WAF allowlist: {e}")
+        return False
+
+
 def main():
     """Main loop"""
     log("=== IP Security List Updater Starting ===")
@@ -176,6 +213,7 @@ def main():
     log(f"Ports: {', '.join(map(str, PORTS))}")
     log(f"Security List ID: {SECURITY_LIST_ID}")
     log(f"NSG ID: {NSG_ID or '(not configured)'}")
+    log(f"WAF Allowlist ID: {WAF_ALLOWLIST_ID or '(not configured)'}")
     log(f"Check Interval: {CHECK_INTERVAL} seconds")
     log(f"Region: {config['region']}")
     
@@ -188,12 +226,13 @@ def main():
         log("ERROR: OCI credentials not properly configured!")
         return
     
-    # Initialize OCI client
+    # Initialize OCI clients
     try:
         virtual_network_client = oci.core.VirtualNetworkClient(config)
-        log("✓ OCI client initialized successfully")
+        waf_client = oci.waf.WafClient(config)
+        log("✓ OCI clients initialized successfully")
     except Exception as e:
-        log(f"ERROR: Failed to initialize OCI client: {e}")
+        log(f"ERROR: Failed to initialize OCI clients: {e}")
         return
     
     current_ip = None
@@ -209,7 +248,8 @@ def main():
                 log(f"IP change detected: {current_ip} -> {new_ip}")
                 sl_ok = update_security_list(virtual_network_client, new_ip)
                 nsg_ok = update_nsg(virtual_network_client, new_ip)
-                if sl_ok and nsg_ok:
+                waf_ok = update_waf_allowlist(waf_client, current_ip, new_ip)
+                if sl_ok and nsg_ok and waf_ok:
                     current_ip = new_ip
             else:
                 log(f"IP unchanged: {current_ip}")


### PR DESCRIPTION
Extends the dynamic-ip-updater to also update the OCI WAF Network
Address List (vars.ocid_WAF_allowlist) whenever the 14monarch IP
changes, alongside the existing Security List and NSG updates.

- update_security_list.py: add WAF_ALLOWLIST_ID env var, initialize
  oci.waf.WafClient, and add update_waf_allowlist() which replaces
  the old /32 CIDR with the new one while preserving other entries
- dynamic-ip-updater-compose.yml: pass WAF_ALLOWLIST_ID into container
- oci-containers-deploy.yml: inject vars.ocid_WAF_allowlist as
  WAF_ALLOWLIST_ID in both Create Stack and Update Stack env blocks

https://claude.ai/code/session_01MRWKpcMByNJMS3csB1qTjt